### PR TITLE
Fixed broken "should NOT see" logic

### DIFF
--- a/step_definitions/visibilty.js
+++ b/step_definitions/visibilty.js
@@ -11,17 +11,20 @@ const { Given } = require('@badeball/cypress-cucumber-preprocessor')
 Given("I {notSee} see {string}{baseElement}", (not_see, text, base_element = '') => {
     cy.not_loading()
 
-    //If we don't detect it anywhere
-    if(Cypress.$(`${window.elementChoices[base_element]}:contains(${JSON.stringify(text)})`).length === 0){
-        expect('html').to.not.contain(text)
-    //If we do detect the text, let us make sure it is not visible on-screen
-    } else {
-        cy.contains(text).then(($elm) => {
-            cy.wait_to_hide_or_detach($elm).then(() => {
-                expect('html').to.not.contain(text)
+    cy.get(window.elementChoices[base_element]).then($elm => {
+        const numberOfOccurences = $elm.find(`:contains(${JSON.stringify(text)})`).length
+        //If we don't detect it anywhere
+        if(numberOfOccurences === 0){
+            expect('html').to.not.contain(text)
+        //If we do detect the text, let us make sure it is not visible on-screen
+        } else {
+            cy.contains(text).then(($elm) => {
+                cy.wait_to_hide_or_detach($elm).then(() => {
+                    expect('html').to.not.contain(text)
+                })
             })
-        })
-    }
+        }
+    })
 })
 
 /**


### PR DESCRIPTION
@aldefouw, I believe this resolves the issue with "should NOT see" not working as expected in all cases, reproduceable as follows:

```
Given I login to REDCap with the user "Test_Admin"
Then I should NOT see "some text that doesn't exist"
```

I believe I've tested it appropriately, but not not 100% confident on all the specifics yet.  What are your thoughts?