### PR TITLE
Fixed issue entering text into Logic Edtior for C.4.18.0700

### DIFF
--- a/step_definitions/interactions.js
+++ b/step_definitions/interactions.js
@@ -513,7 +513,7 @@ Given ('I {enterType} {string} in(to) the textarea field {labeledExactly} {strin
                               cy.wrap($parent).parent().find(element).
                                 click({force: true}).
                                 invoke('attr', 'contenteditable', 'true').
-                                type(`{selectall} {backspace} {backspace} ${text}`, {force: true})
+                                type(`{selectall} {backspace} {backspace} ${text}`, {force: true, delay: 100})
                             } else {
                                 cy.wrap($parent).parent().find(element).clear().type(text)
                             }


### PR DESCRIPTION
@aldefouw, I believe this fixes the issue with characters getting skipped when text is entered into the Logic Editor.