### PR TITLE
Modifies click_on_design_field_function to handle new v14.5 online designer icons

### DIFF
--- a/commands/online_designer.js
+++ b/commands/online_designer.js
@@ -2,6 +2,23 @@
 //# Commands       A B C D E F G H I J K L M N O P Q R S T U V W X Y Z        #
 //#############################################################################
 
+function getFieldAction(type) {
+    switch (type.toLowerCase()) {
+      case 'edit':
+        return 'edit-field';
+      case 'branching logic':
+        return 'branchinglogic';
+      case 'copy':
+        return 'copy-field';
+      case 'move':
+        return 'move-field';
+      case 'delete':
+        return 'delete-field';
+      default:
+        throw new Error(`Unsupported field action type: ${type}`);
+    }
+  }
+
 Cypress.Commands.add('add_field', (field_name, type) => {
     cy.get('input#btn-last').click().then(() => {
         cy.get('select#field_type').select(type).should('have.value', type).then(() => {
@@ -17,7 +34,7 @@ Cypress.Commands.add('click_on_design_field_function', (type, field) => {
     cy.get('td[class=frmedit_row]').
     contains(field).
     parents('tr').
-    find('img[title="' + type + '"]').
+    find(`a[data-field-action="${getFieldAction(type)}"]`).
     click()
 })
 

--- a/commands/online_designer.js
+++ b/commands/online_designer.js
@@ -2,23 +2,6 @@
 //# Commands       A B C D E F G H I J K L M N O P Q R S T U V W X Y Z        #
 //#############################################################################
 
-function getFieldAction(type) {
-    switch (type.toLowerCase()) {
-      case 'edit':
-        return 'edit-field';
-      case 'branching logic':
-        return 'branchinglogic';
-      case 'copy':
-        return 'copy-field';
-      case 'move':
-        return 'move-field';
-      case 'delete':
-        return 'delete-field';
-      default:
-        throw new Error(`Unsupported field action type: ${type}`);
-    }
-  }
-
 Cypress.Commands.add('add_field', (field_name, type) => {
     cy.get('input#btn-last').click().then(() => {
         cy.get('select#field_type').select(type).should('have.value', type).then(() => {
@@ -31,10 +14,13 @@ Cypress.Commands.add('add_field', (field_name, type) => {
 })
 
 Cypress.Commands.add('click_on_design_field_function', (type, field) => {
+    let fieldAction = window.fieldAction[type.toLowerCase()]
+
     cy.get('td[class=frmedit_row]').
     contains(field).
     parents('tr').
-    find(`a[data-field-action="${getFieldAction(type)}"]`).
+    find(`img[title="${type}"],a[data-field-action="${fieldAction}"]`).
+    first().
     click()
 })
 

--- a/step_definitions/support/mappings.js
+++ b/step_definitions/support/mappings.js
@@ -269,3 +269,11 @@ window.tableHtmlElements = {
     '[lock icon]': { selector: 'img[src*=lock]', condition: 'exist' },
     '[e-signed icon]': { selector: 'img[src*=shield]', condition: 'exist' }
 }
+
+window.fieldAction = {
+    'edit': 'edit-field',
+    'branching logic': 'branchinglogic',
+    'copy': 'copy-field',
+    'move': 'move-field',
+    'delete': 'delete-field'
+}


### PR DESCRIPTION
This was a change I made since v14.5 no longer uses the `img[title="Edit"]` for the Online Designer icons. It instead uses `<i>` tags nested within `<a>` tags.

This change **is definitely not** backwards compatible with v13.1.37, v13.7.15, or v14.0.x. Would it be better to first check and see if `img[title="Edit"]` exists first, and if not, _then_ find `a[data-field-action="${getFieldAction(type)}"]`?