### PR TITLE
Online Designer Draggable Field Detection fix

### DIFF
--- a/step_definitions/online_designer.js
+++ b/step_definitions/online_designer.js
@@ -304,8 +304,8 @@ Given("I should see (a )(the )field named {string} {beforeAfter} field named {st
  * @description Creates a new field in the Online Designer
  */
 Given("I add a new {fieldType} field labeled {string} with variable name {string} and click on the {string} button", (field_type, field_text, variable_name, save_button_text) => {
-    const legacy_selector = `${JSON.stringify(`Variable: ${variable_name}`)}`
-    const current_selector = `${JSON.stringify(`Field Name: ${variable_name}`)}`
+    const legacy_selector = `Variable: ${variable_name}`
+    const current_selector = `Field Name: ${variable_name}`
 
     cy.get('input#btn-last').click().then(() => {
         cy.get('select#field_type')

--- a/step_definitions/online_designer.js
+++ b/step_definitions/online_designer.js
@@ -304,8 +304,8 @@ Given("I should see (a )(the )field named {string} {beforeAfter} field named {st
  * @description Creates a new field in the Online Designer
  */
 Given("I add a new {fieldType} field labeled {string} with variable name {string} and click on the {string} button", (field_type, field_text, variable_name, save_button_text) => {
-    const legacy_selector = `table[id*=design-]:contains(${JSON.stringify(`Variable: ${variable_name}`)})`
-    const current_selector = `table[id*=design-]:contains(${JSON.stringify(`Field Name: ${variable_name}`)})`
+    const legacy_selector = `${JSON.stringify(`Variable: ${variable_name}`)}`
+    const current_selector = `${JSON.stringify(`Field Name: ${variable_name}`)}`
 
     cy.get('input#btn-last').click().then(() => {
         cy.get('select#field_type')


### PR DESCRIPTION
@aldefouw & @mmcev106 - this is NOT a solution, but creating a pull request so I can get your help/a discussion going.

A previous commit #10 attempted to address the "I add a new {fieldType} field labeled {string} with variable name {string} and click on the {string} button" step not working for the new Online Designer field names ("Field Name: " instead of "Variable: "), but is not working.

The last command of this step is the following:
```javascript
cy.get('button').contains(save_button_text).click().then(() => {
            cy.get('table#draggable').should(($t) => {
                expect($t).to.contain(`${legacy_selector},${current_selector}`)
            })
        })
```

The `expect($t).to.contain()` line works if I only reference `current_selector` in there. As soon as I try to reference both legacy and current, it can no longer find the field.

I also tried using `contain.oneOf()` with an array containing both the current and legacy selectors, but I keep getting an "couldn't find" error:
```javascript
const selectors = [
        `Variable: ${variable_name}`,
        `Field Name: ${variable_name}`
    ]
...
cy.get('button').contains(save_button_text).click().then(() => {
            cy.get('table#draggable').should(($t) => {
                expect($t).to.contain.oneOf(selectors)
            })
        })
...
AssertionError: Timed out retrying after 60000ms: expected '[ <table#draggable.form_border.container-fluid>, 1 more... ]' to be one of [ Array(2) ]
    at Context.eval (tests?p=redcap_rsvc/Feature%20Tests/A/Project%20Setup_4/A.6.4.0400.%20-%20Draft%20Mode.feature:20141:37)
```

Any suggestions/thoughts?