### PR TITLE
Remain on current page upon logout

### DIFF
--- a/commands/auth.js
+++ b/commands/auth.js
@@ -73,9 +73,13 @@ Cypress.Commands.add('logout', () => {
     cy.getCookie('PHPSESSID').should('not.exist')
     
     cy.url().then((url) => {
-        debugger
-        if (url === 'about:blank') {
+        if (
             // This is the first page load from a blank browser windows
+            url === 'about:blank'
+            ||
+            // Take us back to the homepage so the login form will be displayed
+            url.includes('/surveys/')
+        ) {
             url = '/'
         }
         else {

--- a/commands/auth.js
+++ b/commands/auth.js
@@ -2,6 +2,26 @@
 //# Commands       A B C D E F G H I J K L M N O P Q R S T U V W X Y Z        #
 //#############################################################################
 
+window.adjustInvalidLoginUrls = (url) => {
+    if (
+        // This is the first page load from a blank browser windows
+        url === 'about:blank'
+        ||
+        // Take us back to the homepage so the login form will be displayed
+        url.includes('/surveys/')
+    ) {
+        url = '/'
+    }
+    else {
+        /**
+         * Stay on the existing URL to stay consistent with the actual REDCap behavior
+         * of remaining on the current page upon logging out & back in.
+         */
+    }
+
+    return url
+}
+
 Cypress.Commands.add('fetch_login', (session = true) => {
     let user = window.user_info.get_current_user()
     let pass = window.user_info.get_current_pass()
@@ -46,6 +66,9 @@ Cypress.Commands.add('checkCookieAndLogin', (cookieName, options) => {
                 expect(cookies).to.have.length.greaterThan(0);
                 expect(cookies[0]).to.have.property('name', cookieName)
                 cy.url().then((currentUrl) => {
+                    // The following call is required for restoring snapshots
+                    currentUrl = window.adjustInvalidLoginUrls(currentUrl)
+
                     /**
                      * Stay on the existing URL to stay consistent with the actual REDCap behavior
                      * of remaining on the current page upon logging out & back in.
@@ -72,21 +95,7 @@ Cypress.Commands.add('logout', () => {
     cy.getCookie('PHPSESSID').should('not.exist')
     
     cy.url().then((url) => {
-        if (
-            // This is the first page load from a blank browser windows
-            url === 'about:blank'
-            ||
-            // Take us back to the homepage so the login form will be displayed
-            url.includes('/surveys/')
-        ) {
-            url = '/'
-        }
-        else {
-            /**
-             * Stay on the existing URL to stay consistent with the actual REDCap behavior
-             * of remaining on the current page upon logging out & back in.
-             */
-        }
+        url = window.adjustInvalidLoginUrls(url)
         
         cy.visit(url)
         cy.contains('button', 'Log In').should('exist')

--- a/commands/auth.js
+++ b/commands/auth.js
@@ -26,12 +26,18 @@ Cypress.Commands.add('login', (options, session) => {
     }
 })
 
-Cypress.Commands.add('login_steps', (options) =>{
-    cy.visit_version({page: "", parameters: "action=logout"})
-    cy.get('html').should('contain', 'Log In')
-    cy.get('input[name=username]').invoke('attr', 'value', options['username'])
-    cy.get('input[name=password]').invoke('attr', 'value', options['password'])
-    cy.get('button').contains('Log In').click()
+Cypress.Commands.add('login_steps', (options) => {
+    cy.url().then(url => {
+        /**
+         * Stay on the existing URL to stay consistent with the actual REDCap behavior
+         * of remaining on the current page upon logging out & back in.
+         */
+        cy.url(url)
+        cy.get('html').should('contain', 'Log In')
+        cy.get('input[name=username]').invoke('attr', 'value', options['username'])
+        cy.get('input[name=password]').invoke('attr', 'value', options['password'])
+        cy.get('button').contains('Log In').click()
+    })
 })
 
 Cypress.Commands.add('checkCookieAndLogin', (cookieName, options) => {
@@ -40,11 +46,13 @@ Cypress.Commands.add('checkCookieAndLogin', (cookieName, options) => {
             try {
                 expect(cookies).to.have.length.greaterThan(0);
                 expect(cookies[0]).to.have.property('name', cookieName)
-                // cy.url().then((currentUrl) => {
-                //     if (currentUrl.includes('/surveys/')) {
-                        cy.visit('/')
-                //     }
-                // })
+                cy.url().then((currentUrl) => {
+                    /**
+                     * Stay on the existing URL to stay consistent with the actual REDCap behavior
+                     * of remaining on the current page upon logging out & back in.
+                     */
+                    cy.visit(currentUrl)
+                })
             } catch (error) {
                 if (retries > 0) {
                     cy.log(`Retrying... attempts left: ${retries}`)
@@ -63,8 +71,23 @@ Cypress.Commands.add('checkCookieAndLogin', (cookieName, options) => {
 Cypress.Commands.add('logout', () => {
     cy.clearCookie('PHPSESSID')
     cy.getCookie('PHPSESSID').should('not.exist')
-    cy.visit('/')
-    cy.contains('button', 'Log In').should('exist')
+    
+    cy.url().then((url) => {
+        debugger
+        if (url === 'about:blank') {
+            // This is the first page load from a blank browser windows
+            url = '/'
+        }
+        else {
+            /**
+             * Stay on the existing URL to stay consistent with the actual REDCap behavior
+             * of remaining on the current page upon logging out & back in.
+             */
+        }
+        
+        cy.visit(url)
+        cy.contains('button', 'Log In').should('exist')
+    })
 })
 
 Cypress.Commands.add('set_user_type', (user_type) => {

--- a/commands/auth.js
+++ b/commands/auth.js
@@ -32,7 +32,6 @@ Cypress.Commands.add('login_steps', (options) => {
          * Stay on the existing URL to stay consistent with the actual REDCap behavior
          * of remaining on the current page upon logging out & back in.
          */
-        cy.url(url)
         cy.get('html').should('contain', 'Log In')
         cy.get('input[name=username]').invoke('attr', 'value', options['username'])
         cy.get('input[name=password]').invoke('attr', 'value', options['password'])

--- a/commands/auth.js
+++ b/commands/auth.js
@@ -47,16 +47,10 @@ Cypress.Commands.add('login', (options, session) => {
 })
 
 Cypress.Commands.add('login_steps', (options) => {
-    cy.url().then(url => {
-        /**
-         * Stay on the existing URL to stay consistent with the actual REDCap behavior
-         * of remaining on the current page upon logging out & back in.
-         */
-        cy.get('html').should('contain', 'Log In')
-        cy.get('input[name=username]').invoke('attr', 'value', options['username'])
-        cy.get('input[name=password]').invoke('attr', 'value', options['password'])
-        cy.get('button').contains('Log In').click()
-    })
+    cy.get('html').should('contain', 'Log In')
+    cy.get('input[name=username]').invoke('attr', 'value', options['username'])
+    cy.get('input[name=password]').invoke('attr', 'value', options['password'])
+    cy.get('button').contains('Log In').click()
 })
 
 Cypress.Commands.add('checkCookieAndLogin', (cookieName, options) => {


### PR DESCRIPTION
@aldefouw, the longstanding behavior of RCTF has been to redirect back to the REDCap user homepage after logging out & back in (like when switching users).  This is different than REDCap's actual behavior, which is to remain on the same page.  This has been causing some confusion related to required steps not matching between manual & automated testing.  This PR changes RCTF's behavior to remain on the current page to match the behavior manual testers see.  I have [already run cloud tests](https://cloud.cypress.io/projects/pvu79o/runs/2089/overview?roarHideRunsWithDiffGroupsAndTags=1) including this PR and related [RSVC PR 229](https://github.com/4bbakers/redcap_rsvc/pull/229) to verify that this does not break any of our current automated tests.  There are a couple of test differences on that build, but they're not related to this PR or RSVC PR 229.  I believe this is safe to merge.  Assuming you agree, do you feel comfortable approving RSVC PR 229 as well?  No worries if not.