### PR TITLE
Made it possible to load a specific feature file that allows continuing where the last cypress run left off

### DIFF
--- a/commands/db.js
+++ b/commands/db.js
@@ -29,6 +29,15 @@ Cypress.Commands.add('base_db_seed', () => {
                 cy.visit(line[0])
             })
 
+        } else if (decodeURIComponent(location.href).includes('Continue Last Run.feature')) {
+            cy.readFile('test_db/latest_url.info').then((url) => {
+                /**
+                 * Simply load the previous URL to pick up where we left off.
+                 * Leave the session & DB as-is.
+                 */
+                cy.visit(url)
+            })
+
         } else {
 
             // We can skip populating the base db seed on successive runs by adding a false value to the mysql['initial_db_seed'] key in cypress.env.json

--- a/index.js
+++ b/index.js
@@ -119,6 +119,20 @@ function rctf_initialize(preprocessor) {
 
     beforeEach(abortEarly);
     afterEach(abortEarly);
+
+    after(() => {
+        if (Cypress.config('isInteractive')) {
+            /**
+             * We are a developer likely running a single feature at a time via the Cypress UI.
+             * Automatically save the user & page in case the developer wants to load "Continue Last Run.feature"
+             * and pick up where they left off.
+             */
+            //Snapshot of the URL and session
+            cy.url().then((url) => {
+                cy.task('saveCurrentURL', ({ url: url }))
+            })
+        }
+    })
 }
 
 // // This is what makes these functions available to outside scripts

--- a/index.js
+++ b/index.js
@@ -127,7 +127,6 @@ function rctf_initialize(preprocessor) {
              * Automatically save the user & page in case the developer wants to load "Continue Last Run.feature"
              * and pick up where they left off.
              */
-            //Snapshot of the URL and session
             cy.url().then((url) => {
                 cy.task('saveCurrentURL', ({ url: url }))
             })

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -97,6 +97,12 @@ module.exports = (cypressOn, config) => {
             })
         },
 
+        saveCurrentURL({ url }) {
+            let path = shell.pwd() + '/test_db/latest_url.info'
+            shell.ShellString(`${url}`).to(path)
+            return fs.existsSync(path)
+        },
+
         currentSnapshotInfo({url, user, pass}){
             let snapshot_url_path = shell.pwd() + '/test_db/latest_snapshot.info'
             shell.ShellString(`${url}\n${user}\n${pass}`).to(snapshot_url_path);


### PR DESCRIPTION
@aldefouw, this one is higher priority, as it will immediately save Adam L & Ellis considerable time.  This is meant to  be considered alongside https://github.com/4bbakers/redcap_rsvc/pull/233.  To test this PR, create the file added to `.gitignore` in https://github.com/4bbakers/redcap_rsvc/pull/233 on your local.  I am working on another related change for redcap_cypress_docker that will include documentation and auto create this file with the following content:

```
Feature: Continue Last Run
    Scenario: Continue Last Run
        Given I replace this step with whatever step(s) I want to test on the fly
```

The goal here is similar to the snapshot feature, but this one aims to save even more time with typical development workflows.  The last URL is automatically saved after every feature finishes (regardless of success or failure).  The developer then has the option of instructing cypress to continuing from the current page & current state of the database by loading a special `Continue Last Run.feature` file in Cypress.  In this file the developer can place one or more steps they want to try to execute for immediate troubleshooting at any given time.