### PR TITLE
C.2.19.500

### DIFF
--- a/commands/online_designer.js
+++ b/commands/online_designer.js
@@ -106,7 +106,22 @@ Cypress.Commands.add('select_radio_by_label', ($name, $value, $click = true, $se
             }
         } else {
             // Fallback to the nearest radio button - whether that is next or previous parent
+            const action = (radio) => {
+                if ($click) {
+                    radio.click()
+                } else {
+                    radio.should('have.attr', $selected ? 'checked' : 'unchecked')
+                }
+            }
+
             cy.contains($value).then($text => {
+                const radios = $text.find('input[type=radio]')
+                if (radios.length === 1) {
+                    // The the text and matching radio are the only siblings within a div (e.g. "Lock/Unlock Records").
+                    action(radios[0])
+                    return
+                }
+
                 const parent = Cypress.$($text).parent()
                 let radio = parent
 
@@ -117,11 +132,7 @@ Cypress.Commands.add('select_radio_by_label', ($name, $value, $click = true, $se
                 }
 
                 if (radio.length) {
-                    if ($click) {
-                        cy.wrap(radio).find('input[type=radio]').click();
-                    } else {
-                        cy.wrap(radio).find('input[type=radio]').should('have.attr', $selected ? 'checked' : 'unchecked');
-                    }
+                    cy.wrap(radio).find('input[type=radio]').then(action)
                 }
             })
         }


### PR DESCRIPTION
@aldefouw, this is meant to be reviewed alongside https://github.com/4bbakers/redcap_rsvc/pull/234/files

Comparing the following two cloud build results confirms that these changes do not affect any features other than C.2.19.500:
![image](https://github.com/user-attachments/assets/c38c5d27-2e7c-4fe4-a58e-acbcd6ed0fc1)

This PR includes two commits that make it possible to use simpler gherkin language in C.2.19.500 (and future features):
- The "top most dialog" changes are much more significant, and are well described in the code comments.  I believe this is a really important change, as it will allow us to simplify the gherkin required in many scenarios.  For example, this change likely makes all `in the dialog box` language extraneous, since it changes the expectation such that we always search in dialogs by default.  This brings RCTF behavior more in line with user expectations.
- The radio selection improvement covers an additional case where a radio and it's label are direct siblings, and no other radios exist as direct siblings.