### PR TITLE
Add backwards compatibility for session cookie check in `auth.js`

### DIFF
--- a/commands/auth.js
+++ b/commands/auth.js
@@ -70,12 +70,12 @@ Cypress.Commands.add('checkCookieAndLogin', (options) => {
             try {
                 expect(cookies).to.have.length.greaterThan(0);
 
-                let sessionCookieFound = false
+                let sessionCookieFound = false;
                 cookies.forEach(cookie => {
-                    if(cookie.name.startsWith('redcap_session_')){
-                        sessionCookieFound = true
+                    if (cookie.name.startsWith('redcap_session_') || cookie.name.startsWith('PHPSESSID')) {
+                        sessionCookieFound = true;
                     }
-                })
+                });
                 
                 if(!sessionCookieFound){
                     throw 'Session cookie not found!'


### PR DESCRIPTION
The most recent changes to session cookie handling in `auth.js` resulted in broken feature tests when testing against REDCap versions < `15.7.0`. 

Since many of us in the consortium use these automated tests for validating LTS instances, I propose that logic is added for both cookie nomenclatures (`redcap_session_` and `PHPSESSID`) to ensure test compatibility across standard and LTS branches.

If there is a more graceful or preferred way to handle this logic, I am happy to edit my PR. I have tested this change for feature tests running against `15.5.7`, `15.5.20`, `15.8.1`, `15.8.4` without issue (running `Chrome 142`, `Cypress 14.5.0`).