### PR TITLE
Pass in the results to the afterRunHandler within plugins/index.js

### DIFF
--- a/plugins/index.js
+++ b/plugins/index.js
@@ -68,7 +68,7 @@ module.exports = (cypressOn, config) => {
     })
 
     on("after:run", async (results) => {
-        afterRunHandler(config);
+        afterRunHandler(config, results);
 
         // Your own `after:run` code goes here.
     })


### PR DESCRIPTION
This is a bug that I found when testing in CI.

# Pre-flight Checklist
- [X] Have all lines in this PR been reviewed & optimized by a human with appropriate coding skills? 
- [X] Are all the features in this PR tested by a human? 
- [X] Have other features this PR touches also been tested by a human?
- [X] Has the code been formatted for consistency and readability?
- [X] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
Simple fix.  We were missing the results parameter being passed into afterRunHandler.

# Context
I cherry-pick the commit from the draft PR I have:
https://github.com/vanderbilt-redcap/rctf/pull/86#pullrequestreview-4298832601
