### PR TITLE
Allowed enabling EMs on every test via env configuration

### DIFF
--- a/commands/base.js
+++ b/commands/base.js
@@ -1545,23 +1545,17 @@ Cypress.Commands.add("getLabeledElement", {prevSubject: 'optional'}, function (s
     })
 })
 
-window.getExternalModuleDetails = () => {
+window.getCurrentExternalModuleDirectory = () => {
     const parts = window.original_spec_path.split('/redcap_source/modules/')
     if(parts.length === 1){
-        return false
+        return null
     }
 
-    const moduleDirName = parts[1].split('/')[0]
-    const i = moduleDirName.lastIndexOf('_')
-
-    return {
-        prefix: moduleDirName.substr(0, i),
-        version: moduleDirName.substr(i+1),
-    }
+    return parts[1].split('/')[0]
 }
 
 window.isExternalModuleFeature = () => {
-    return window.getExternalModuleDetails() !== false
+    return window.getCurrentExternalModuleDirectory() !== null
 }
 
 window.getFilePathForCurrentFeature = (path) => {

--- a/commands/db.js
+++ b/commands/db.js
@@ -4,12 +4,27 @@
 
 Cypress.Commands.add('base_db_seed', () => {
     const getAdditionalDatabaseSeedQueries = () => {
-        const queries = []
+        const moduleDirNames = []
 
-        const emDetails = window.getExternalModuleDetails()
-        if(emDetails){
-            queries.push(`INSERT INTO redcap_external_modules(directory_prefix) VALUES ('${emDetails.prefix}')`)
-            queries.push(`INSERT INTO redcap_external_module_settings VALUES (LAST_INSERT_ID(), null, 'version', 'string', '${emDetails.version}')`)
+        for (const [moduleDirName, enabled] of Object.entries(Cypress.env('bootstrap_settings')['modules'])) {
+            if(enabled){
+                moduleDirNames.push(moduleDirName)
+            }
+        }       
+
+        const currentModuleDirName = window.getCurrentExternalModuleDirectory()
+        if(currentModuleDirName){
+            moduleDirNames.push(currentModuleDirName)
+        }
+        
+        const queries = []
+        for(const moduleDirName of moduleDirNames){
+            const i = moduleDirName.lastIndexOf('_')
+            const prefix = moduleDirName.substr(0, i)
+            const version = moduleDirName.substr(i+1)
+
+            queries.push(`INSERT INTO redcap_external_modules(directory_prefix) VALUES ('${prefix}')`)
+            queries.push(`INSERT INTO redcap_external_module_settings VALUES (LAST_INSERT_ID(), null, 'version', 'string', '${version}')`)
         }
 
         if(queries.length === 0){

--- a/commands/db.js
+++ b/commands/db.js
@@ -10,7 +10,7 @@ Cypress.Commands.add('base_db_seed', () => {
             if(enabled){
                 moduleDirNames.push(moduleDirName)
             }
-        }       
+        }
 
         const currentModuleDirName = window.getCurrentExternalModuleDirectory()
         if(currentModuleDirName){

--- a/commands/db.js
+++ b/commands/db.js
@@ -6,7 +6,7 @@ Cypress.Commands.add('base_db_seed', () => {
     const getAdditionalDatabaseSeedQueries = () => {
         const moduleDirNames = []
 
-        for (const [moduleDirName, enabled] of Object.entries(Cypress.env('bootstrap_settings')['modules'])) {
+        for (const [moduleDirName, enabled] of Object.entries(Cypress.env('bootstrap_settings')['modules'] ?? {})) {
             if(enabled){
                 moduleDirNames.push(moduleDirName)
             }


### PR DESCRIPTION
@aldefouw, I realized my recent change to auto-enable the current EM when EM features would make it trivial to also support enabling EMs on all features via env.  Does this PR work for you in place of #86?  It aims to accomplish the same goal without taking any additional time at beginning of the test.